### PR TITLE
Keep previous $IFS, do not lose it

### DIFF
--- a/dtags/shells/bash.py
+++ b/dtags/shells/bash.py
@@ -44,9 +44,10 @@ d() {{
         return 2
     fi
     declare -a _dtags_dirs
+    PREV_IFS=$IFS
     IFS=$'\n'
     _dtags_dirs=($(grep -E ",$1(,|$)" {mapping_file} | cut -d',' -f1))
-    unset $IFS
+    IFS=$PREV_IFS
     declare _dtags_count=${{#_dtags_dirs[@]}}
     if [[ $_dtags_count -eq 0 ]]
     then

--- a/dtags/shells/zsh.py
+++ b/dtags/shells/zsh.py
@@ -44,9 +44,10 @@ d() {{
         return 2
     fi
     declare -a _dtags_dirs
+    PREV_IFS=$IFS
     IFS=$'\n'
     _dtags_dirs=($(grep -E ",$1(,|$)" {mapping_file} | cut -d',' -f1))
-    unset $IFS
+    IFS=$PREV_IFS
     declare _dtags_count=${{#_dtags_dirs[@]}}
 
     if [[ $_dtags_count -eq 0 ]]


### PR DESCRIPTION
This fix a bug because when unset $IFS, it loses the previous $IFS and could be anything defined for the shell.

As good practice is set it to your needs only for the duration of your requirement and set it back to the previous one.