### PR TITLE
zsh: unalias `d` if alias is present

### DIFF
--- a/dtags/shells/zsh.py
+++ b/dtags/shells/zsh.py
@@ -1,5 +1,6 @@
 CONFIGURATION = """
-d() {{
+unalias d &> /dev/null
+function d() {{
     declare _dtags_usage='{usage}'
     declare _dtags_version='{version}'
     declare _dtags_description='{description}'


### PR DESCRIPTION
Some shell configuration utilities (in particular oh-my-zsh does this)
might already have an alias for `d` that the user did not set himself.

Unalias d in .zshrc to ensure the alias is set properly.