### PR TITLE
[WIP] Support `d -` to go to $OLDPWD

### DIFF
--- a/dtags/shells/zsh.py
+++ b/dtags/shells/zsh.py
@@ -35,6 +35,11 @@ function d() {{
     then
         printf "Version $_dtags_version\n"
         return 0
+    elif [[ $1 = - ]]
+    then
+        printf "$_dtags_goto_msg" "$OLDPWD"
+        cd "$OLDPWD"
+        return 0
     elif [[ $1 = -* ]]
     then
         printf "$_dtags_arg_err" "$_dtags_usage" "$1"


### PR DESCRIPTION
The shell builtin `cd` will go to the $OLDPWD upon `cd -`. Also support
this feature in the directory command `d`.